### PR TITLE
Setup: master brief + subagents + CODEOWNERS + overlap guard

### DIFF
--- a/.claude/agents/backend-api.md
+++ b/.claude/agents/backend-api.md
@@ -1,0 +1,6 @@
+---
+name: backend-api
+description: "FastAPI routers, DTOs, auth, error handling."
+tools: Bash, Read, Write, Edit
+---
+Scope: /backend/app/routers/** and /backend/app/schemas/**

--- a/.claude/agents/charting-dev.md
+++ b/.claude/agents/charting-dev.md
@@ -1,0 +1,6 @@
+---
+name: charting-dev
+description: "Lightweight Charts, multi-pane layouts, indicators, real-time perf."
+tools: Bash, Read, Write, Edit
+---
+Scope: /frontend/src/features/charts/**

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -1,0 +1,7 @@
+---
+name: frontend-dev
+description: "React + TS architecture, routing, state, performance."
+tools: Bash, Read, Write, Edit
+---
+Work only in /frontend/** and components referenced by the map.
+Add tests and update the Work Log.

--- a/.claude/agents/market-data.md
+++ b/.claude/agents/market-data.md
@@ -1,0 +1,6 @@
+---
+name: market-data
+description: "Provider adapters, retries, caching, rate limits."
+tools: Bash, Read, Write, Edit
+---
+Scope: /backend/app/providers/** and /backend/app/services/market_data/**

--- a/.claude/agents/project-supervisor.md
+++ b/.claude/agents/project-supervisor.md
@@ -1,0 +1,11 @@
+---
+name: project-supervisor
+description: "Master coordinator that analyzes, plans, delegates to specialists, and enforces scopes & work log updates."
+tools: Bash, Read, Write, Edit
+---
+Read `master_brief.md` and `component_map.yaml`.
+Protocol:
+- Break down tasks → delegate to specialists
+- Ensure each PR updates `master_brief.md §6` and includes tests
+- Keep specialists within component paths; avoid collisions
+- Use PR template and request CODEOWNERS review

--- a/.claude/agents/test-specialist.md
+++ b/.claude/agents/test-specialist.md
@@ -1,0 +1,6 @@
+---
+name: test-specialist
+description: "Jest/RTL (FE) and pytest/FastAPI (BE). Coverage and reliability."
+tools: Bash, Read, Write, Edit
+---
+Own tests across touched areas; keep CI green.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "project": "NovaSignal",
+  "default_supervisor": "project-supervisor",
+  "enforce_scopes": true,
+  "brief_path": "master_brief.md"
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @kaydenraquel-crypto

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### Summary
+Describe the change and the user-visible impact.
+
+### Component(s) touched
+- comp:
+
+### Scope
+- Paths changed:
+- Linked Issue(s): #
+
+### Testing
+- [ ] Unit tests
+- [ ] Integration/E2E
+- [ ] Manual QA notes
+
+### Docs
+- [ ] Updated `master_brief.md` (§6 Work Log + Decisions)

--- a/.github/workflows/prevent-overlap.yml
+++ b/.github/workflows/prevent-overlap.yml
@@ -1,0 +1,42 @@
+name: Prevent Path Overlap
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  path-lock:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check overlap with other open PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const current = context.payload.pull_request.number;
+            async function filesOf(prNumber) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: prNumber, per_page: 100
+              });
+              return files.map(f => f.filename);
+            }
+            const currentFiles = new Set(await filesOf(current));
+            const openPRs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+            const overlaps = [];
+            for (const pr of openPRs) {
+              if (pr.number === current || pr.draft) continue;
+              const otherFiles = await filesOf(pr.number);
+              const shared = otherFiles.filter(f => currentFiles.has(f));
+              if (shared.length) overlaps.push({num: pr.number, title: pr.title, shared});
+            }
+            if (overlaps.length) {
+              const msg = overlaps.map(o => `- PR #${o.num} "${o.title}"\n  Overlap: ${o.shared.slice(0,20).join(', ')}`).join('\n');
+              core.setFailed(`This PR overlaps files modified by other open PRs:\n${msg}\n\nCoordinate ownership or retarget to a shared feature branch.`);
+            } else {
+              core.info('No overlapping files with other open PRs.');
+            }

--- a/component_map.yaml
+++ b/component_map.yaml
@@ -2,45 +2,24 @@ components:
   frontend:
     paths:
       - /frontend/**
-    owners: [@kaydenraquel-crypto]
-  charts:
+  charting-dev:
     paths:
       - /frontend/src/features/charts/**
-      - /backend/app/routers/market_data.py
-    owners: [@kaydenraquel-crypto]
   backend-api:
     paths:
       - /backend/app/routers/**
       - /backend/app/schemas/**
-      - /backend/app/dependencies/**
-    owners: [@kaydenraquel-crypto]
   market-data:
     paths:
       - /backend/app/providers/**
       - /backend/app/services/market_data/**
-    owners: [@kaydenraquel-crypto]
   signals-engine:
     paths:
       - /backend/app/signals/**
       - /backend/app/backtesting/**
-    owners: [@kaydenraquel-crypto]
   ai-engine:
     paths:
       - /fingpt_server/**
-    owners: [@kaydenraquel-crypto]
-  installer:
-    paths:
-      - /installer/**
-      - /install.ps1
-    owners: [@kaydenraquel-crypto]
-  helm-k8s:
-    paths:
-      - /helm/**
-    owners: [@kaydenraquel-crypto]
-  ci-cd:
-    paths:
-      - /.github/workflows/**
-    owners: [@kaydenraquel-crypto]
   docs:
     paths:
       - /docs/**
@@ -48,4 +27,3 @@ components:
       - /project_progress_summary.md
       - /project_todo.md
       - /CHANGELOG.md
-    owners: [@kaydenraquel-crypto]

--- a/master_brief.md
+++ b/master_brief.md
@@ -1,12 +1,13 @@
 # NovaSignal — Master Brief
-_Updated: 2025-08-26_
-
-See `component_map.yaml` for ownership. Use `.claude/agents/*` for file-based Claude Code agents.
+Read this first. Agents must:
+- Work within their component scope (see `component_map.yaml`)
+- Write tests and update §6 Work Log
+- Open PRs; CODEOWNERS review is required
 
 ## Phases
-- Stabilize
-- Grow
-- Harden
+1) Stabilize (providers, error boundaries) 
+2) Grow (charts v2, signals/backtests, AI flows)
+3) Harden (perf, E2E, packaging)
 
-## Work Log (§6)
-Append Date / Branch / Scope / Decisions / Risks.
+## §6 Work Log (append)
+- Date / Agent / Component / Files touched / Decisions / Next


### PR DESCRIPTION
## Summary
Adds brief, component map, CODEOWNERS, PR template, and Prevent Path Overlap workflow.

## Component(s) touched
- comp: docs, ci-cd

## Scope
- Paths changed: .github/, .claude/, master_brief.md, component_map.yaml
- Linked Issue(s): #

## Testing
- [ ] Unit tests
- [ ] Integration/E2E
- [ ] Manual QA notes

## Docs
- [ ] Updated `master_brief.md` (§6 Work Log + Decisions)

🤖 Generated with [Claude Code](https://claude.ai/code)